### PR TITLE
Add "release/" prefix to release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
     on:
       tags: false
       branch: master
-  # Release-candidate ('x.x' release branches)
+  # Release-candidate ('release/x.x' release branches)
   - provider: pages
     local-dir: releases
     skip-cleanup: true
@@ -58,7 +58,7 @@ deploy:
     on:
       tags: false
       all_branches: true
-      condition: $TRAVIS_BRANCH =~ ^[0-9]+\.[0-9]+$
+      condition: $TRAVIS_BRANCH =~ ^release/[0-9]+\.[0-9]+$
   # Release (tags)
   - provider: releases
     file_glob: true


### PR DESCRIPTION
This will allow to set consistent branch rules for all release branches (thanks @Arrnas for telling about this).