### PR TITLE
Fix naming clash by using 'Publisher' name

### DIFF
--- a/src/app/data-fetchers/country-list.js
+++ b/src/app/data-fetchers/country-list.js
@@ -20,7 +20,7 @@ import type { Country } from '../countries'
 import Publisher from '../../libraries/publisher'
 import { getSortedCountryListFromProposals } from '../countries'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import type { FavoriteProviders } from '../user-settings/user-settings'
 import type { ProposalFetcher } from './proposal-fetcher'
 import type { UserSettingsStore } from '../user-settings/user-settings-store'
@@ -41,8 +41,8 @@ class CountryList {
     this._subscribeToFavoriteChanges()
   }
 
-  onUpdate (listener: Callback<Array<Country>>) {
-    this._publisher.subscribe(listener)
+  onUpdate (listener: Subscriber<Array<Country>>) {
+    this._publisher.addSubscriber(listener)
   }
 
   _subscribeToFavoriteChanges () {
@@ -53,7 +53,7 @@ class CountryList {
   }
 
   _notify () {
-    this._publisher.notify(getSortedCountryListFromProposals(this._proposals, this._favorites))
+    this._publisher.publish(getSortedCountryListFromProposals(this._proposals, this._favorites))
   }
 
   _subscribeToProposalFetches () {

--- a/src/app/data-fetchers/country-list.js
+++ b/src/app/data-fetchers/country-list.js
@@ -17,10 +17,10 @@
 
 // @flow
 import type { Country } from '../countries'
-import Subscriber from '../../libraries/subscriber'
+import Publisher from '../../libraries/publisher'
 import { getSortedCountryListFromProposals } from '../countries'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
-import type { Callback } from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
 import type { FavoriteProviders } from '../user-settings/user-settings'
 import type { ProposalFetcher } from './proposal-fetcher'
 import type { UserSettingsStore } from '../user-settings/user-settings-store'
@@ -29,7 +29,7 @@ import { userSettingName } from '../user-settings/user-settings-store'
 class CountryList {
   _proposalFetcher: ProposalFetcher
   _userSettingsStore: UserSettingsStore
-  _listeners: Subscriber<Array<Country>> = new Subscriber()
+  _publisher: Publisher<Array<Country>> = new Publisher()
 
   _proposals: ProposalDTO[] = []
   _favorites: FavoriteProviders = new Set()
@@ -42,7 +42,7 @@ class CountryList {
   }
 
   onUpdate (listener: Callback<Array<Country>>) {
-    this._listeners.subscribe(listener)
+    this._publisher.subscribe(listener)
   }
 
   _subscribeToFavoriteChanges () {
@@ -53,7 +53,7 @@ class CountryList {
   }
 
   _notify () {
-    this._listeners.notify(getSortedCountryListFromProposals(this._proposals, this._favorites))
+    this._publisher.notify(getSortedCountryListFromProposals(this._proposals, this._favorites))
   }
 
   _subscribeToProposalFetches () {

--- a/src/app/data-fetchers/proposal-fetcher.js
+++ b/src/app/data-fetchers/proposal-fetcher.js
@@ -17,7 +17,7 @@
 
 // @flow
 
-import type { Callback } from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
 
 interface ProposalFetcher {

--- a/src/app/data-fetchers/proposal-fetcher.js
+++ b/src/app/data-fetchers/proposal-fetcher.js
@@ -17,12 +17,12 @@
 
 // @flow
 
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
 
 interface ProposalFetcher {
   fetch(): Promise<ProposalDTO[]>,
-  onFetchedProposals(Callback<ProposalDTO[]>): void
+  onFetchedProposals(Subscriber<ProposalDTO[]>): void
 }
 
 export type { ProposalFetcher }

--- a/src/app/data-fetchers/registration-fetcher.js
+++ b/src/app/data-fetchers/registration-fetcher.js
@@ -17,7 +17,7 @@
 
 // @flow
 
-import type { Callback } from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
 import IdentityRegistrationDTO from 'mysterium-tequilapi/lib/dto/identity-registration'
 
 interface RegistrationFetcher {

--- a/src/app/data-fetchers/registration-fetcher.js
+++ b/src/app/data-fetchers/registration-fetcher.js
@@ -17,12 +17,12 @@
 
 // @flow
 
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import IdentityRegistrationDTO from 'mysterium-tequilapi/lib/dto/identity-registration'
 
 interface RegistrationFetcher {
   fetch(): Promise<IdentityRegistrationDTO>,
-  onFetchedRegistration(Callback<IdentityRegistrationDTO>): void
+  onFetchedRegistration(Subscriber<IdentityRegistrationDTO>): void
 }
 
 export type { RegistrationFetcher }

--- a/src/app/data-fetchers/tequilapi-proposal-fetcher.js
+++ b/src/app/data-fetchers/tequilapi-proposal-fetcher.js
@@ -20,7 +20,7 @@
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import { FunctionLooper } from '../../libraries/function-looper'
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import Publisher from '../../libraries/publisher'
 import type { ProposalFetcher } from './proposal-fetcher'
 
@@ -37,7 +37,7 @@ class TequilapiProposalFetcher implements ProposalFetcher {
       await this.fetch()
     }, interval)
     this._loop.onFunctionError((error) => {
-      this._errorPublisher.notify(error)
+      this._errorPublisher.publish(error)
     })
   }
 
@@ -54,7 +54,7 @@ class TequilapiProposalFetcher implements ProposalFetcher {
   async fetch (): Promise<ProposalDTO[]> {
     const proposals = await this._api.findProposals()
 
-    this._proposalPublisher.notify(proposals)
+    this._proposalPublisher.publish(proposals)
 
     return proposals
   }
@@ -63,12 +63,12 @@ class TequilapiProposalFetcher implements ProposalFetcher {
     await this._loop.stop()
   }
 
-  onFetchedProposals (subscriber: Callback<ProposalDTO[]>): void {
-    this._proposalPublisher.subscribe(subscriber)
+  onFetchedProposals (subscriber: Subscriber<ProposalDTO[]>): void {
+    this._proposalPublisher.addSubscriber(subscriber)
   }
 
-  onFetchingError (subscriber: Callback<Error>): void {
-    this._errorPublisher.subscribe(subscriber)
+  onFetchingError (subscriber: Subscriber<Error>): void {
+    this._errorPublisher.addSubscriber(subscriber)
   }
 }
 

--- a/src/app/data-fetchers/tequilapi-proposal-fetcher.js
+++ b/src/app/data-fetchers/tequilapi-proposal-fetcher.js
@@ -20,15 +20,15 @@
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import { FunctionLooper } from '../../libraries/function-looper'
-import type { Callback } from '../../libraries/subscriber'
-import Subscriber from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
+import Publisher from '../../libraries/publisher'
 import type { ProposalFetcher } from './proposal-fetcher'
 
 class TequilapiProposalFetcher implements ProposalFetcher {
   _api: TequilapiClient
   _loop: FunctionLooper
-  _proposalSubscriber: Subscriber<ProposalDTO[]> = new Subscriber()
-  _errorSubscriber: Subscriber<Error> = new Subscriber()
+  _proposalPublisher: Publisher<ProposalDTO[]> = new Publisher()
+  _errorPublisher: Publisher<Error> = new Publisher()
 
   constructor (api: TequilapiClient, interval: number = 5000) {
     this._api = api
@@ -37,7 +37,7 @@ class TequilapiProposalFetcher implements ProposalFetcher {
       await this.fetch()
     }, interval)
     this._loop.onFunctionError((error) => {
-      this._errorSubscriber.notify(error)
+      this._errorPublisher.notify(error)
     })
   }
 
@@ -54,7 +54,7 @@ class TequilapiProposalFetcher implements ProposalFetcher {
   async fetch (): Promise<ProposalDTO[]> {
     const proposals = await this._api.findProposals()
 
-    this._proposalSubscriber.notify(proposals)
+    this._proposalPublisher.notify(proposals)
 
     return proposals
   }
@@ -64,11 +64,11 @@ class TequilapiProposalFetcher implements ProposalFetcher {
   }
 
   onFetchedProposals (subscriber: Callback<ProposalDTO[]>): void {
-    this._proposalSubscriber.subscribe(subscriber)
+    this._proposalPublisher.subscribe(subscriber)
   }
 
   onFetchingError (subscriber: Callback<Error>): void {
-    this._errorSubscriber.subscribe(subscriber)
+    this._errorPublisher.subscribe(subscriber)
   }
 }
 

--- a/src/app/data-fetchers/tequilapi-registration-fetcher.js
+++ b/src/app/data-fetchers/tequilapi-registration-fetcher.js
@@ -19,16 +19,16 @@
 
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import { FunctionLooper } from '../../libraries/function-looper'
-import type { Callback } from '../../libraries/subscriber'
-import Subscriber from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
+import Publisher from '../../libraries/publisher'
 import type { RegistrationFetcher } from './registration-fetcher'
 import IdentityRegistrationDTO from 'mysterium-tequilapi/lib/dto/identity-registration'
 
 class TequilapiRegistrationFetcher implements RegistrationFetcher {
   _api: TequilapiClient
   _loop: FunctionLooper
-  _registrationSubscriber: Subscriber<IdentityRegistrationDTO> = new Subscriber()
-  _errorSubscriber: Subscriber<Error> = new Subscriber()
+  _registrationPublisher: Publisher<IdentityRegistrationDTO> = new Publisher()
+  _errorPublisher: Publisher<Error> = new Publisher()
   _identityId: string
 
   constructor (api: TequilapiClient, interval: number = 5000) {
@@ -38,7 +38,7 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
       await this.fetch()
     }, interval)
     this._loop.onFunctionError((error) => {
-      this._errorSubscriber.notify(error)
+      this._errorPublisher.notify(error)
     })
   }
 
@@ -58,7 +58,7 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
   async fetch (): Promise<IdentityRegistrationDTO> {
     const registration = await this._api.identityRegistration(this._identityId)
 
-    this._registrationSubscriber.notify(registration)
+    this._registrationPublisher.notify(registration)
 
     return registration
   }
@@ -68,11 +68,11 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
   }
 
   onFetchedRegistration (subscriber: Callback<IdentityRegistrationDTO>): void {
-    this._registrationSubscriber.subscribe(subscriber)
+    this._registrationPublisher.subscribe(subscriber)
   }
 
   onFetchingError (subscriber: Callback<Error>): void {
-    this._errorSubscriber.subscribe(subscriber)
+    this._errorPublisher.subscribe(subscriber)
   }
 }
 

--- a/src/app/data-fetchers/tequilapi-registration-fetcher.js
+++ b/src/app/data-fetchers/tequilapi-registration-fetcher.js
@@ -19,7 +19,7 @@
 
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import { FunctionLooper } from '../../libraries/function-looper'
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import Publisher from '../../libraries/publisher'
 import type { RegistrationFetcher } from './registration-fetcher'
 import IdentityRegistrationDTO from 'mysterium-tequilapi/lib/dto/identity-registration'
@@ -38,7 +38,7 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
       await this.fetch()
     }, interval)
     this._loop.onFunctionError((error) => {
-      this._errorPublisher.notify(error)
+      this._errorPublisher.publish(error)
     })
   }
 
@@ -58,7 +58,7 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
   async fetch (): Promise<IdentityRegistrationDTO> {
     const registration = await this._api.identityRegistration(this._identityId)
 
-    this._registrationPublisher.notify(registration)
+    this._registrationPublisher.publish(registration)
 
     return registration
   }
@@ -67,12 +67,12 @@ class TequilapiRegistrationFetcher implements RegistrationFetcher {
     await this._loop.stop()
   }
 
-  onFetchedRegistration (subscriber: Callback<IdentityRegistrationDTO>): void {
-    this._registrationPublisher.subscribe(subscriber)
+  onFetchedRegistration (subscriber: Subscriber<IdentityRegistrationDTO>): void {
+    this._registrationPublisher.addSubscriber(subscriber)
   }
 
-  onFetchingError (subscriber: Callback<Error>): void {
-    this._errorPublisher.subscribe(subscriber)
+  onFetchingError (subscriber: Subscriber<Error>): void {
+    this._errorPublisher.addSubscriber(subscriber)
   }
 }
 

--- a/src/app/user-settings/observable-user-settings.js
+++ b/src/app/user-settings/observable-user-settings.js
@@ -20,7 +20,7 @@
 import type { FavoriteProviders, UserSettings } from './user-settings'
 import { Observable } from '../../libraries/observable'
 import type { UserSettingName } from './user-settings-store'
-import type { Callback } from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
 import { userSettingName } from './user-settings-store'
 
 function getDefaultSettings (): UserSettings {
@@ -36,7 +36,7 @@ type ObservableSettings = {
 }
 
 /**
- * Keeps user settings and notifies subscribers when settings change.
+ * Keeps user settings and publishes changes to subscribers.
  */
 class ObservableUserSettings {
   _observables: ObservableSettings

--- a/src/app/user-settings/observable-user-settings.js
+++ b/src/app/user-settings/observable-user-settings.js
@@ -20,7 +20,7 @@
 import type { FavoriteProviders, UserSettings } from './user-settings'
 import { Observable } from '../../libraries/observable'
 import type { UserSettingName } from './user-settings-store'
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 import { userSettingName } from './user-settings-store'
 
 function getDefaultSettings (): UserSettings {
@@ -53,12 +53,12 @@ class ObservableUserSettings {
     return (settings: any)
   }
 
-  onChange (property: UserSettingName, callback: Callback<any>) {
-    this._observables[property].subscribe(callback)
+  onChange (property: UserSettingName, callback: Subscriber<any>) {
+    this._observables[property].addSubscriber(callback)
   }
 
-  removeOnChange (property: UserSettingName, callback: Callback<any>) {
-    this._observables[property].unsubscribe(callback)
+  removeOnChange (property: UserSettingName, callback: Subscriber<any>) {
+    this._observables[property].removeSubscriber(callback)
   }
 
   _buildObservables (): ObservableSettings {

--- a/src/app/user-settings/user-settings-store.js
+++ b/src/app/user-settings/user-settings-store.js
@@ -17,7 +17,7 @@
 
 // @flow
 import type { UserSettings } from './user-settings'
-import type { Callback } from '../../libraries/subscriber'
+import type { Callback } from '../../libraries/publisher'
 
 const userSettingName = {
   showDisconnectNotifications: 'showDisconnectNotifications',

--- a/src/app/user-settings/user-settings-store.js
+++ b/src/app/user-settings/user-settings-store.js
@@ -17,7 +17,7 @@
 
 // @flow
 import type { UserSettings } from './user-settings'
-import type { Callback } from '../../libraries/publisher'
+import type { Subscriber } from '../../libraries/publisher'
 
 const userSettingName = {
   showDisconnectNotifications: 'showDisconnectNotifications',
@@ -30,8 +30,8 @@ interface UserSettingsStore {
   setFavorite (id: string, isFavorite: boolean): Promise<void>,
   setShowDisconnectNotifications (show: boolean): Promise<void>,
   getAll (): UserSettings,
-  onChange (property: UserSettingName, callback: Callback<any>): void,
-  removeOnChange (property: UserSettingName, callback: Callback<any>): void
+  onChange (property: UserSettingName, callback: Subscriber<any>): void,
+  removeOnChange (property: UserSettingName, callback: Subscriber<any>): void
 }
 
 export type { UserSettingsStore, UserSettingName }

--- a/src/libraries/function-looper.js
+++ b/src/libraries/function-looper.js
@@ -122,7 +122,7 @@ class FunctionLooper {
         this._currentExecutor = new ThresholdExecutor(
           this._func,
           this._threshold,
-          (err) => this._errorPublisher.notify(err)
+          (err) => this._errorPublisher.publish(err)
         )
         this._currentPromise = this._currentExecutor.execute()
         await this._currentPromise
@@ -141,7 +141,7 @@ class FunctionLooper {
   }
 
   onFunctionError (callback: (Error) => void) {
-    this._errorPublisher.subscribe(callback)
+    this._errorPublisher.addSubscriber(callback)
   }
 
   async _waitForStartedPromise (): Promise<void> {

--- a/src/libraries/function-looper.js
+++ b/src/libraries/function-looper.js
@@ -17,7 +17,7 @@
 
 // @flow
 import sleep from './sleep'
-import Subscriber from './subscriber'
+import Publisher from './publisher'
 
 type AsyncFunctionWithoutParams = () => Promise<any>
 
@@ -101,7 +101,7 @@ class FunctionLooper {
   _func: AsyncFunctionWithoutParams
   _threshold: number
   _running: boolean = false
-  _errorSubscriber: Subscriber<Error> = new Subscriber()
+  _errorPublisher: Publisher<Error> = new Publisher()
   _currentExecutor: ?ThresholdExecutor
   _currentPromise: ?Promise<void>
 
@@ -122,7 +122,7 @@ class FunctionLooper {
         this._currentExecutor = new ThresholdExecutor(
           this._func,
           this._threshold,
-          (err) => this._errorSubscriber.notify(err)
+          (err) => this._errorPublisher.notify(err)
         )
         this._currentPromise = this._currentExecutor.execute()
         await this._currentPromise
@@ -141,7 +141,7 @@ class FunctionLooper {
   }
 
   onFunctionError (callback: (Error) => void) {
-    this._errorSubscriber.subscribe(callback)
+    this._errorPublisher.subscribe(callback)
   }
 
   async _waitForStartedPromise (): Promise<void> {

--- a/src/libraries/mysterium-client/client-log-publisher.js
+++ b/src/libraries/mysterium-client/client-log-publisher.js
@@ -75,7 +75,7 @@ class ClientLogPublisher {
       throw new Error(`Unknown process logging level: ${level}`)
     }
 
-    this._publishers[level].subscribe(cb)
+    this._publishers[level].addSubscriber(cb)
   }
 
   _tailLogs () {
@@ -120,7 +120,7 @@ class ClientLogPublisher {
   }
 
   _notifySubscribersWithLog (level: string, data: string): void {
-    this._publishers[level].notify(data)
+    this._publishers[level].publish(data)
   }
 
   _tailFile (filePath: string, subscriberCallback: LogCallback): void {

--- a/src/libraries/mysterium-client/client-log-publisher.js
+++ b/src/libraries/mysterium-client/client-log-publisher.js
@@ -18,15 +18,15 @@
 // @flow
 import fs from 'fs'
 import type { BugReporter } from '../../app/bug-reporting/interface'
-import Subscriber from '../subscriber'
+import Publisher from '../publisher'
 import logLevels from './log-levels'
 import type { LogCallback } from './index'
 import createFileIfMissing from '../create-file-if-missing'
 import { INVERSE_DOMAIN_PACKAGE_NAME } from './launch-daemon/config'
 import { toISOString, prependWithFn } from '../strings'
 
-type Subscribers = {
-  [logLevels.INFO | logLevels.ERROR]: Subscriber<string>,
+type Publishers = {
+  [logLevels.INFO | logLevels.ERROR]: Publisher<string>,
 }
 
 type DateFunction = () => Date
@@ -34,8 +34,8 @@ type TailFunction = (filePath: string, logCallback: LogCallback) => void
 
 const prependWithSpace = prependWithFn(() => ` `)
 
-class ClientLogSubscriber {
-  _subscribers: Subscribers
+class ClientLogPublisher {
+  _publishers: Publishers
   _bugReporter: BugReporter
   _stdoutPath: string
   _stderrPath: string
@@ -58,9 +58,9 @@ class ClientLogSubscriber {
     this._dateFunction = dateFunction
     this._tailFunction = tailFunction
 
-    this._subscribers = {
-      [logLevels.INFO]: new Subscriber(),
-      [logLevels.ERROR]: new Subscriber()
+    this._publishers = {
+      [logLevels.INFO]: new Publisher(),
+      [logLevels.ERROR]: new Publisher()
     }
   }
 
@@ -71,11 +71,11 @@ class ClientLogSubscriber {
   }
 
   onLog (level: string, cb: LogCallback): void {
-    if (!this._subscribers[level]) {
+    if (!this._publishers[level]) {
       throw new Error(`Unknown process logging level: ${level}`)
     }
 
-    this._subscribers[level].subscribe(cb)
+    this._publishers[level].subscribe(cb)
   }
 
   _tailLogs () {
@@ -120,7 +120,7 @@ class ClientLogSubscriber {
   }
 
   _notifySubscribersWithLog (level: string, data: string): void {
-    this._subscribers[level].notify(data)
+    this._publishers[level].notify(data)
   }
 
   _tailFile (filePath: string, subscriberCallback: LogCallback): void {
@@ -133,5 +133,5 @@ class ClientLogSubscriber {
   }
 }
 
-export default ClientLogSubscriber
+export default ClientLogPublisher
 export type { TailFunction }

--- a/src/libraries/mysterium-client/index.js
+++ b/src/libraries/mysterium-client/index.js
@@ -17,10 +17,10 @@
 
 // @flow
 
-import type { Callback } from '../publisher'
+import type { Subscriber } from '../publisher'
 import logLevels from './log-levels'
 
-type LogCallback = Callback<any>
+type LogCallback = Subscriber<any>
 
 interface Installer {
   needsInstallation (): Promise<boolean>,

--- a/src/libraries/mysterium-client/index.js
+++ b/src/libraries/mysterium-client/index.js
@@ -17,7 +17,7 @@
 
 // @flow
 
-import type { Callback } from '../subscriber'
+import type { Callback } from '../publisher'
 import logLevels from './log-levels'
 
 type LogCallback = Callback<any>

--- a/src/libraries/mysterium-client/launch-daemon/launch-daemon-process.js
+++ b/src/libraries/mysterium-client/launch-daemon/launch-daemon-process.js
@@ -20,7 +20,7 @@
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import type { LogCallback, Process } from '../index'
 import axios from 'axios'
-import ClientLogSubscriber from '../client-log-subscriber'
+import ClientLogPublisher from '../client-log-publisher'
 import Monitoring from '../monitoring/monitoring'
 import logger from '../../../app/logger'
 import VersionCheck from '../version-check'
@@ -33,19 +33,19 @@ import config from '../../../renderer/config'
 class LaunchDaemonProcess implements Process {
   _tequilapi: TequilapiClient
   _daemonPort: number
-  _logs: ClientLogSubscriber
+  _logs: ClientLogPublisher
   _monitoring: Monitoring
   _versionCheck: VersionCheck
 
   /**
    * @constructor
    * @param {TequilapiClient} tequilapi - api to be used
-   * @param {ClientLogSubscriber} logs
+   * @param {ClientLogPublisher} logs
    * @param {string} daemonPort - port at which the daemon is spawned
    */
   constructor (
     tequilapi: TequilapiClient,
-    logs: ClientLogSubscriber,
+    logs: ClientLogPublisher,
     daemonPort: number,
     monitoring: Monitoring,
     versionCheck: VersionCheck) {

--- a/src/libraries/mysterium-client/monitoring/monitoring.js
+++ b/src/libraries/mysterium-client/monitoring/monitoring.js
@@ -16,10 +16,10 @@
  */
 
 // @flow
-import Subscriber from '../../subscriber'
+import Publisher from '../../publisher'
 import type { StatusNotifier } from './status-notifier'
 import { onFirstEventOrTimeout } from '../../../app/events'
-import type { Unsubscribe } from '../../subscriber'
+import type { Unsubscribe } from '../../publisher'
 
 const HEALTH_CHECK_INTERVAL = 1500
 
@@ -30,11 +30,11 @@ const MYSTERIUM_CLIENT_WAITING_THRESHOLD = 10000
 
 // TODO: ensure that users unsubscribe
 class Monitoring {
-  _statusSubscriber: Subscriber<boolean> = new Subscriber()
-  _upSubscriber: Subscriber<void> = new Subscriber()
-  _downSubscriber: Subscriber<void> = new Subscriber()
-  _changeUpSubscriber: Subscriber<void> = new Subscriber()
-  _changeDownSubscriber: Subscriber<void> = new Subscriber()
+  _statusPublisher: Publisher<boolean> = new Publisher()
+  _upPublisher: Publisher<void> = new Publisher()
+  _downPublisher: Publisher<void> = new Publisher()
+  _changeUpPublisher: Publisher<void> = new Publisher()
+  _changeDownPublisher: Publisher<void> = new Publisher()
 
   _lastStatus: ?boolean = null
 
@@ -73,7 +73,7 @@ class Monitoring {
    * Triggers once service is up. Does not trigger instantly if it is already up.
    */
   onNewStatusUp (callback: EmptyCallback): Unsubscribe {
-    return this._upSubscriber.subscribe(callback)
+    return this._upPublisher.subscribe(callback)
   }
 
   waitForNewStatusUpWithTimeout (): Promise<void> {
@@ -84,7 +84,7 @@ class Monitoring {
    * Triggers once service status changes to up.
    */
   onStatusChangeUp (callback: EmptyCallback): Unsubscribe {
-    return this._changeUpSubscriber.subscribe(callback)
+    return this._changeUpPublisher.subscribe(callback)
   }
 
   /**
@@ -105,7 +105,7 @@ class Monitoring {
    * Triggers once service is down. Does not trigger instantly if it is already down.
    */
   onNewStatusDown (callback: EmptyCallback): Unsubscribe {
-    return this._downSubscriber.subscribe(callback)
+    return this._downPublisher.subscribe(callback)
   }
 
   waitForNewStatusDownWithTimeout (): Promise<void> {
@@ -116,7 +116,7 @@ class Monitoring {
    * Triggers once service status changes to down.
    */
   onStatusChangeDown (callback: EmptyCallback): Unsubscribe {
-    return this._changeDownSubscriber.subscribe(callback)
+    return this._changeDownPublisher.subscribe(callback)
   }
 
   _updateStatus (status: boolean) {
@@ -125,12 +125,12 @@ class Monitoring {
   }
 
   _triggerStatus (status: boolean) {
-    this._statusSubscriber.notify(status)
+    this._statusPublisher.notify(status)
 
     if (status) {
-      this._upSubscriber.notify()
+      this._upPublisher.notify()
     } else {
-      this._downSubscriber.notify()
+      this._downPublisher.notify()
     }
 
     if (status !== this._lastStatus) {
@@ -147,11 +147,11 @@ class Monitoring {
   }
 
   _triggerStatusChangeUp () {
-    this._changeUpSubscriber.notify()
+    this._changeUpPublisher.notify()
   }
 
   _triggerStatusChangeDown () {
-    this._changeDownSubscriber.notify()
+    this._changeDownPublisher.notify()
   }
 }
 

--- a/src/libraries/mysterium-client/monitoring/monitoring.js
+++ b/src/libraries/mysterium-client/monitoring/monitoring.js
@@ -73,7 +73,7 @@ class Monitoring {
    * Triggers once service is up. Does not trigger instantly if it is already up.
    */
   onNewStatusUp (callback: EmptyCallback): Unsubscribe {
-    return this._upPublisher.subscribe(callback)
+    return this._upPublisher.addSubscriber(callback)
   }
 
   waitForNewStatusUpWithTimeout (): Promise<void> {
@@ -84,7 +84,7 @@ class Monitoring {
    * Triggers once service status changes to up.
    */
   onStatusChangeUp (callback: EmptyCallback): Unsubscribe {
-    return this._changeUpPublisher.subscribe(callback)
+    return this._changeUpPublisher.addSubscriber(callback)
   }
 
   /**
@@ -105,7 +105,7 @@ class Monitoring {
    * Triggers once service is down. Does not trigger instantly if it is already down.
    */
   onNewStatusDown (callback: EmptyCallback): Unsubscribe {
-    return this._downPublisher.subscribe(callback)
+    return this._downPublisher.addSubscriber(callback)
   }
 
   waitForNewStatusDownWithTimeout (): Promise<void> {
@@ -116,7 +116,7 @@ class Monitoring {
    * Triggers once service status changes to down.
    */
   onStatusChangeDown (callback: EmptyCallback): Unsubscribe {
-    return this._changeDownPublisher.subscribe(callback)
+    return this._changeDownPublisher.addSubscriber(callback)
   }
 
   _updateStatus (status: boolean) {
@@ -125,12 +125,12 @@ class Monitoring {
   }
 
   _triggerStatus (status: boolean) {
-    this._statusPublisher.notify(status)
+    this._statusPublisher.publish(status)
 
     if (status) {
-      this._upPublisher.notify()
+      this._upPublisher.publish()
     } else {
-      this._downPublisher.notify()
+      this._downPublisher.publish()
     }
 
     if (status !== this._lastStatus) {
@@ -147,11 +147,11 @@ class Monitoring {
   }
 
   _triggerStatusChangeUp () {
-    this._changeUpPublisher.notify()
+    this._changeUpPublisher.publish()
   }
 
   _triggerStatusChangeDown () {
-    this._changeDownPublisher.notify()
+    this._changeDownPublisher.publish()
   }
 }
 

--- a/src/libraries/mysterium-client/monitoring/tequilapi-status-notifier.js
+++ b/src/libraries/mysterium-client/monitoring/tequilapi-status-notifier.js
@@ -19,7 +19,7 @@
 
 import type { StatusNotifier } from './status-notifier'
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
-import Subscriber from '../../subscriber'
+import Publisher from '../../publisher'
 import type { StatusCallback } from './monitoring'
 import { HEALTH_CHECK_INTERVAL } from './monitoring'
 
@@ -32,7 +32,7 @@ class TequilapiStatusNotifier implements StatusNotifier {
 
   _isStarted: boolean = false
 
-  _statusSubscriber: Subscriber<boolean> = new Subscriber()
+  _statusPublisher: Publisher<boolean> = new Publisher()
 
   constructor (tequilapi: TequilapiClient) {
     this._api = tequilapi
@@ -54,7 +54,7 @@ class TequilapiStatusNotifier implements StatusNotifier {
   }
 
   onStatus (callback: StatusCallback): void {
-    this._statusSubscriber.subscribe(callback)
+    this._statusPublisher.subscribe(callback)
   }
 
   async _healthCheckLoop (): Promise<void> {
@@ -83,7 +83,7 @@ class TequilapiStatusNotifier implements StatusNotifier {
   }
 
   _updateStatus (status: boolean) {
-    this._statusSubscriber.notify(status)
+    this._statusPublisher.notify(status)
   }
 }
 

--- a/src/libraries/mysterium-client/monitoring/tequilapi-status-notifier.js
+++ b/src/libraries/mysterium-client/monitoring/tequilapi-status-notifier.js
@@ -54,7 +54,7 @@ class TequilapiStatusNotifier implements StatusNotifier {
   }
 
   onStatus (callback: StatusCallback): void {
-    this._statusPublisher.subscribe(callback)
+    this._statusPublisher.addSubscriber(callback)
   }
 
   async _healthCheckLoop (): Promise<void> {
@@ -83,7 +83,7 @@ class TequilapiStatusNotifier implements StatusNotifier {
   }
 
   _updateStatus (status: boolean) {
-    this._statusPublisher.notify(status)
+    this._statusPublisher.publish(status)
   }
 }
 

--- a/src/libraries/mysterium-client/service-manager/service-manager-process.js
+++ b/src/libraries/mysterium-client/service-manager/service-manager-process.js
@@ -21,7 +21,7 @@ import logger from '../../../app/logger'
 import type { LogCallback, Process } from '../index'
 import type { TequilapiClient } from 'mysterium-tequilapi/lib/client'
 import type { System } from '../system'
-import ClientLogSubscriber from '../client-log-subscriber'
+import ClientLogPublisher from '../client-log-publisher'
 import { HEALTH_CHECK_INTERVAL } from '../monitoring/monitoring'
 import ServiceManager, { SERVICE_STATE } from './service-manager'
 import type { ServiceState } from './service-manager'
@@ -41,14 +41,14 @@ const SERVICE_CHECK_TIME = HEALTH_CHECK_INTERVAL
 
 class ServiceManagerProcess implements Process {
   _tequilapi: TequilapiClient
-  _logs: ClientLogSubscriber
+  _logs: ClientLogPublisher
   _serviceManager: ServiceManager
   _system: System
   _repairIsRunning: boolean = false
 
   constructor (
     tequilapi: TequilapiClient,
-    logs: ClientLogSubscriber,
+    logs: ClientLogPublisher,
     serviceManager: ServiceManager,
     system: System) {
     this._tequilapi = tequilapi

--- a/src/libraries/observable.js
+++ b/src/libraries/observable.js
@@ -18,7 +18,7 @@
 // @flow
 
 import logger from '../app/logger'
-import type { Callback } from './publisher'
+import type { Subscriber } from './publisher'
 import Publisher from './publisher'
 
 /**
@@ -37,15 +37,15 @@ class Observable<T> {
       return
     }
     this._value = value
-    this._publisher.notify(value)
+    this._publisher.publish(value)
   }
 
   constructor (initialValue: T) {
     this._value = initialValue
   }
 
-  subscribe (callback: Callback<T>) {
-    this._publisher.subscribe(callback)
+  addSubscriber (callback: Subscriber<T>) {
+    this._publisher.addSubscriber(callback)
     try {
       callback(this._value)
     } catch (err) {
@@ -53,8 +53,8 @@ class Observable<T> {
     }
   }
 
-  unsubscribe (callback: Callback<T>) {
-    this._publisher.unsubscribe(callback)
+  removeSubscriber (callback: Subscriber<T>) {
+    this._publisher.removeSubscriber(callback)
   }
 }
 

--- a/src/libraries/observable.js
+++ b/src/libraries/observable.js
@@ -18,15 +18,15 @@
 // @flow
 
 import logger from '../app/logger'
-import type { Callback } from './subscriber'
-import Subscriber from './subscriber'
+import type { Callback } from './publisher'
+import Publisher from './publisher'
 
 /**
  * Stores value and allows subscribing to value changes.
  */
 class Observable<T> {
   _value: T
-  _subscriber: Subscriber<T> = new Subscriber()
+  _publisher: Publisher<T> = new Publisher()
 
   get value (): T {
     return this._value
@@ -37,7 +37,7 @@ class Observable<T> {
       return
     }
     this._value = value
-    this._subscriber.notify(value)
+    this._publisher.notify(value)
   }
 
   constructor (initialValue: T) {
@@ -45,7 +45,7 @@ class Observable<T> {
   }
 
   subscribe (callback: Callback<T>) {
-    this._subscriber.subscribe(callback)
+    this._publisher.subscribe(callback)
     try {
       callback(this._value)
     } catch (err) {
@@ -54,7 +54,7 @@ class Observable<T> {
   }
 
   unsubscribe (callback: Callback<T>) {
-    this._subscriber.unsubscribe(callback)
+    this._publisher.unsubscribe(callback)
   }
 }
 

--- a/src/libraries/publisher.js
+++ b/src/libraries/publisher.js
@@ -19,30 +19,30 @@
 
 import logger from '../app/logger'
 
-type Callback<T> = (T) => any
+type Subscriber<T> = (T) => any
 type Unsubscribe = () => void
 
 /**
  * Allows subscribing callbacks and publishing data to them.
  */
 class Publisher<T> {
-  _callbacks: Array<Callback<T>> = []
+  _subscribers: Array<Subscriber<T>> = []
 
-  subscribe (callback: Callback<T>): Unsubscribe {
-    this._callbacks.push(callback)
-    return () => { this.unsubscribe(callback) }
+  addSubscriber (subscriber: Subscriber<T>): Unsubscribe {
+    this._subscribers.push(subscriber)
+    return () => { this.removeSubscriber(subscriber) }
   }
 
-  unsubscribe (callback: Callback<T>) {
-    const index = this._callbacks.indexOf(callback)
+  removeSubscriber (subscriber: Subscriber<T>) {
+    const index = this._subscribers.indexOf(subscriber)
     if (index === -1) {
       throw new Error('Callback being unsubscribed was not found')
     }
-    this._callbacks.splice(index, 1)
+    this._subscribers.splice(index, 1)
   }
 
-  notify (data: T) {
-    this._callbacks.forEach((callback: Callback<T>) => {
+  publish (data: T) {
+    this._subscribers.forEach((callback: Subscriber<T>) => {
       try {
         callback(data)
       } catch (err) {
@@ -52,6 +52,6 @@ class Publisher<T> {
   }
 }
 
-export type { Callback, Unsubscribe }
+export type { Subscriber, Unsubscribe }
 
 export default Publisher

--- a/src/libraries/publisher.js
+++ b/src/libraries/publisher.js
@@ -23,9 +23,9 @@ type Callback<T> = (T) => any
 type Unsubscribe = () => void
 
 /**
- * Allows subscribing callbacks and notifying them with data.
+ * Allows subscribing callbacks and publishing data to them.
  */
-class Subscriber<T> {
+class Publisher<T> {
   _callbacks: Array<Callback<T>> = []
 
   subscribe (callback: Callback<T>): Unsubscribe {
@@ -46,7 +46,7 @@ class Subscriber<T> {
       try {
         callback(data)
       } catch (err) {
-        logger.error('Callback call in Subscriber failed', err)
+        logger.error('Callback call in Publisher failed', err)
       }
     })
   }
@@ -54,4 +54,4 @@ class Subscriber<T> {
 
 export type { Callback, Unsubscribe }
 
-export default Subscriber
+export default Publisher

--- a/test/helpers/mysterium-client/monitoring-mock.js
+++ b/test/helpers/mysterium-client/monitoring-mock.js
@@ -35,7 +35,7 @@ class MockStatusNotifier implements StatusNotifier {
   }
 
   onStatus (callback: StatusCallback): void {
-    this._statusPublisher.subscribe(callback)
+    this._statusPublisher.addSubscriber(callback)
     const status = this._lastStatus
     if (status != null) {
       // TODO: remove this initial invokation in this class?
@@ -44,7 +44,7 @@ class MockStatusNotifier implements StatusNotifier {
   }
 
   notifyStatus (status: boolean) {
-    this._statusPublisher.notify(status)
+    this._statusPublisher.publish(status)
   }
 }
 

--- a/test/helpers/mysterium-client/monitoring-mock.js
+++ b/test/helpers/mysterium-client/monitoring-mock.js
@@ -19,13 +19,13 @@
 
 import type { StatusCallback }
   from '../../../src/libraries/mysterium-client/monitoring/monitoring'
-import Subscriber from '../../../src/libraries/subscriber'
+import Publisher from '../../../src/libraries/publisher'
 import type { StatusNotifier } from '../../../src/libraries/mysterium-client/monitoring/status-notifier'
 
 class MockStatusNotifier implements StatusNotifier {
   _started: boolean = false
   _lastStatus: ?boolean = null
-  _statusSubscriber: Subscriber<boolean> = new Subscriber()
+  _statusPublisher: Publisher<boolean> = new Publisher()
 
   start (): void {
     this._started = true
@@ -35,7 +35,7 @@ class MockStatusNotifier implements StatusNotifier {
   }
 
   onStatus (callback: StatusCallback): void {
-    this._statusSubscriber.subscribe(callback)
+    this._statusPublisher.subscribe(callback)
     const status = this._lastStatus
     if (status != null) {
       // TODO: remove this initial invokation in this class?
@@ -44,7 +44,7 @@ class MockStatusNotifier implements StatusNotifier {
   }
 
   notifyStatus (status: boolean) {
-    this._statusSubscriber.notify(status)
+    this._statusPublisher.notify(status)
   }
 }
 

--- a/test/integration/libraries/mysterium-client/client-log-publisher.spec.js
+++ b/test/integration/libraries/mysterium-client/client-log-publisher.spec.js
@@ -21,14 +21,14 @@ import type { LogCallback } from '../../../../src/libraries/mysterium-client'
 import logLevels from '../../../../src/libraries/mysterium-client/log-levels'
 import BugReporterMock from '../../../helpers/bug-reporter-mock'
 import { afterEach, beforeEach, describe, expect, it } from '../../../helpers/dependencies'
-import ClientLogSubscriber from '../../../../src/libraries/mysterium-client/client-log-subscriber'
+import ClientLogPublisher from '../../../../src/libraries/mysterium-client/client-log-publisher'
 import { existsSync, unlinkSync } from 'fs'
 import path from 'path'
 import { CallbackRecorder } from '../../../helpers/utils'
 
-describe('ClientLogSubscriber', () => {
+describe('ClientLogPublisher', () => {
   let logCallbackParam = ''
-  let subscriber
+  let publisher
   const stdout = path.join(process.cwd(), __dirname, 'stdout.log')
   const stderr = path.join(process.cwd(), __dirname, 'stderr.log')
   const dateFunction = () => new Date('2018-01-01')
@@ -37,7 +37,7 @@ describe('ClientLogSubscriber', () => {
   }
 
   beforeEach(() => {
-    subscriber = new ClientLogSubscriber(new BugReporterMock(), stdout, stderr, stdout, dateFunction, tailFunction)
+    publisher = new ClientLogPublisher(new BugReporterMock(), stdout, stderr, stdout, dateFunction, tailFunction)
   })
 
   afterEach(() => {
@@ -50,7 +50,7 @@ describe('ClientLogSubscriber', () => {
       expect(existsSync(stdout)).to.be.false
       expect(existsSync(stderr)).to.be.false
 
-      await subscriber.setup()
+      await publisher.setup()
 
       expect(existsSync(stdout)).to.be.true
       expect(existsSync(stderr)).to.be.true
@@ -62,9 +62,9 @@ describe('ClientLogSubscriber', () => {
       logCallbackParam = 'info line'
 
       const sub = new CallbackRecorder()
-      subscriber.onLog(logLevels.INFO, sub.getCallback())
+      publisher.onLog(logLevels.INFO, sub.getCallback())
 
-      await subscriber.setup()
+      await publisher.setup()
 
       expect(sub.invoked).to.be.true
       expect(sub.arguments).to.be.eql([logCallbackParam])
@@ -74,9 +74,9 @@ describe('ClientLogSubscriber', () => {
       logCallbackParam = 'error line'
       const sub = new CallbackRecorder()
 
-      subscriber.onLog(logLevels.ERROR, sub.getCallback())
+      publisher.onLog(logLevels.ERROR, sub.getCallback())
 
-      await subscriber.setup()
+      await publisher.setup()
 
       expect(sub.invoked).to.be.true
       expect(sub.arguments).to.be.eql(['2018-01-01T00:00:00.000Z error line'])

--- a/test/unit/app/data-fetchers/country-list.spec.js
+++ b/test/unit/app/data-fetchers/country-list.spec.js
@@ -18,7 +18,7 @@
 // @flow
 import type { ProposalFetcher } from '../../../../src/app/data-fetchers/proposal-fetcher'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
-import type { Callback } from '../../../../src/libraries/subscriber'
+import type { Callback } from '../../../../src/libraries/publisher'
 import { afterEach, beforeEach, describe, expect, it } from '../../../helpers/dependencies'
 import CountryList from '../../../../src/app/data-fetchers/country-list'
 import { UserSettingsStorage } from '../../../../src/app/user-settings/user-settings-storage'

--- a/test/unit/app/data-fetchers/country-list.spec.js
+++ b/test/unit/app/data-fetchers/country-list.spec.js
@@ -18,7 +18,7 @@
 // @flow
 import type { ProposalFetcher } from '../../../../src/app/data-fetchers/proposal-fetcher'
 import ProposalDTO from 'mysterium-tequilapi/lib/dto/proposal'
-import type { Callback } from '../../../../src/libraries/publisher'
+import type { Subscriber } from '../../../../src/libraries/publisher'
 import { afterEach, beforeEach, describe, expect, it } from '../../../helpers/dependencies'
 import CountryList from '../../../../src/app/data-fetchers/country-list'
 import { UserSettingsStorage } from '../../../../src/app/user-settings/user-settings-storage'
@@ -27,7 +27,7 @@ import { unlinkSyncIfPresent } from '../../../helpers/file-system'
 import type { UserSettingsStore } from '../../../../src/app/user-settings/user-settings-store'
 
 class ProposalFetcherMock implements ProposalFetcher {
-  _subscriber: Callback<ProposalDTO[]>
+  _subscriber: Subscriber<ProposalDTO[]>
   _data: ProposalDTO[]
 
   async fetch (): Promise<Array<ProposalDTO>> {
@@ -35,7 +35,7 @@ class ProposalFetcherMock implements ProposalFetcher {
     return this._data
   }
 
-  onFetchedProposals (cb: Callback<ProposalDTO[]>) {
+  onFetchedProposals (cb: Subscriber<ProposalDTO[]>) {
     this._subscriber = cb
   }
 

--- a/test/unit/libraries/mysterium-client/launch-daemon/launch-daemon-process.spec.js
+++ b/test/unit/libraries/mysterium-client/launch-daemon/launch-daemon-process.spec.js
@@ -17,7 +17,7 @@
 
 // @flow
 
-import ClientLogSubscriber from '../../../../../src/libraries/mysterium-client/client-log-subscriber'
+import ClientLogPublisher from '../../../../../src/libraries/mysterium-client/client-log-publisher'
 import BugReporterMock from '../../../../helpers/bug-reporter-mock'
 import { after, before, beforeEach, describe, expect, it } from '../../../../helpers/dependencies'
 import LaunchDaemonProcess from '../../../../../src/libraries/mysterium-client/launch-daemon/launch-daemon-process'
@@ -59,14 +59,14 @@ describe('LaunchDaemonProcess', () => {
   let processStarted: boolean
 
   beforeEach(() => {
-    const logSubscriber = new ClientLogSubscriber(new BugReporterMock(), '', '', '', () => new Date(), () => {})
+    const logPublisher = new ClientLogPublisher(new BugReporterMock(), '', '', '', () => new Date(), () => {})
     tequilApi = new TequilapiClientMock()
     notifierMock = new MockStatusNotifier()
     monitoring = new Monitoring(notifierMock)
     monitoring.start()
     process = new LaunchDaemonProcess(
       tequilApi,
-      logSubscriber,
+      logPublisher,
       1234,
       monitoring,
       new VersionCheck(tequilApi, '1.1.0')

--- a/test/unit/libraries/mysterium-client/service-manager/service-manager-process.spec.js
+++ b/test/unit/libraries/mysterium-client/service-manager/service-manager-process.spec.js
@@ -25,7 +25,7 @@ import EmptyTequilapiClientMock from '../../../renderer/store/modules/empty-tequ
 import SystemMock from '../../../../helpers/system-mock'
 import type { NodeHealthcheckDTO } from 'mysterium-tequilapi/lib/dto/node-healthcheck'
 import NodeBuildInfoDTO from 'mysterium-tequilapi/lib/dto/node-build-info'
-import ClientLogSubscriber from '../../../../../src/libraries/mysterium-client/client-log-subscriber'
+import ClientLogPublisher from '../../../../../src/libraries/mysterium-client/client-log-publisher'
 import type { LogCallback } from '../../../../../src/libraries/mysterium-client'
 import type { SystemMockManager } from '../../../../helpers/system-mock'
 import type { System } from '../../../../../src/libraries/mysterium-client/system'
@@ -84,7 +84,7 @@ class TequilapiMock extends EmptyTequilapiClientMock {
   }
 }
 
-class ClientLogSubscriberMock extends ClientLogSubscriber {
+class ClientLogPublisherMock extends ClientLogPublisher {
   constructor () {
     const bugReporter = new BugReporterMock()
     super(bugReporter, '', '', '', () => new Date(), (filePath: string, logCallback: LogCallback) => {})
@@ -102,7 +102,7 @@ describe('ServiceManagerProcess', () => {
   let system: System
   let tequilapiClient: TequilapiMock
   let process: ServiceManagerProcess
-  let clientLogSubscriber: ClientLogSubscriberMock
+  let clientLogPublisher: ClientLogPublisherMock
   let serviceManager: ServiceManager
   let clock: lolex
 
@@ -145,11 +145,11 @@ describe('ServiceManagerProcess', () => {
     systemMockManager = (systemMock: SystemMockManager)
 
     tequilapiClient = new TequilapiMock()
-    clientLogSubscriber = new ClientLogSubscriberMock()
+    clientLogPublisher = new ClientLogPublisherMock()
     const mockNotifier = new MockStatusNotifier()
     const monitoring = new Monitoring(mockNotifier)
     serviceManager = new ServiceManager(SERVICE_MANAGER_PATH, system, monitoring)
-    process = new ServiceManagerProcess(tequilapiClient, clientLogSubscriber, serviceManager, system)
+    process = new ServiceManagerProcess(tequilapiClient, clientLogPublisher, serviceManager, system)
   })
 
   describe('.start', () => {

--- a/test/unit/libraries/observable.spec.js
+++ b/test/unit/libraries/observable.spec.js
@@ -32,20 +32,20 @@ describe('Observable', () => {
     })
 
     it('invokes callback instantly with current value', () => {
-      observable.subscribe(recorder.getCallback())
+      observable.addSubscriber(recorder.getCallback())
       expect(recorder.invokesCount).to.eql(1)
       expect(recorder.lastArguments).to.eql([{ hey: 'how' }])
     })
 
     it('invokes callback with new value when it changes', () => {
-      observable.subscribe(recorder.getCallback())
+      observable.addSubscriber(recorder.getCallback())
       observable.value = { hello: 'world' }
       expect(recorder.invokesCount).to.eql(2)
       expect(recorder.lastArguments).to.eql([{ hello: 'world' }])
     })
 
     it('does not invoke callback when same value is set', () => {
-      observable.subscribe(recorder.getCallback())
+      observable.addSubscriber(recorder.getCallback())
       observable.value = { hey: 'how' }
       expect(recorder.invokesCount).to.eql(1)
     })

--- a/test/unit/libraries/publisher.spec.js
+++ b/test/unit/libraries/publisher.spec.js
@@ -27,46 +27,46 @@ describe('Publisher', () => {
     publisher = new Publisher()
   })
 
-  it('notifies each event', () => {
+  it('publishes each event', () => {
     const values: Array<string> = []
-    publisher.subscribe((value: string) => {
+    publisher.addSubscriber((value: string) => {
       values.push(value)
     })
 
-    publisher.notify('hello')
-    publisher.notify('world')
+    publisher.publish('hello')
+    publisher.publish('world')
 
     expect(values).to.eql(['hello', 'world'])
   })
 
-  it('notifies multiple subscribers', () => {
+  it('publishes event to multiple subscribers', () => {
     let value1 = null
     let value2 = null
-    publisher.subscribe((value: string) => {
+    publisher.addSubscriber((value: string) => {
       value1 = value
     })
-    publisher.subscribe((value: string) => {
+    publisher.addSubscriber((value: string) => {
       value2 = value
     })
 
-    publisher.notify('hey')
+    publisher.publish('hey')
 
     expect(value1).to.eql('hey')
     expect(value2).to.eql('hey')
   })
 
-  it('notifies all subscribers when first is failing', () => {
+  it('publishes event to all subscribers when first is failing', () => {
     let value1 = null
     let value2 = null
-    publisher.subscribe((value: string) => {
+    publisher.addSubscriber((value: string) => {
       value1 = value
       throw new Error('mock error')
     })
-    publisher.subscribe((value: string) => {
+    publisher.addSubscriber((value: string) => {
       value2 = value
     })
 
-    publisher.notify('hey')
+    publisher.publish('hey')
 
     expect(value1).to.eql('hey')
     expect(value2).to.eql('hey')
@@ -74,23 +74,23 @@ describe('Publisher', () => {
 
   it('returns function which unsubscribes', () => {
     const values: Array<string> = []
-    const unsubscribe = publisher.subscribe((value: string) => {
+    const unsubscribe = publisher.addSubscriber((value: string) => {
       values.push(value)
     })
 
-    publisher.notify('hello')
+    publisher.publish('hello')
     unsubscribe()
-    publisher.notify('world')
+    publisher.publish('world')
 
     expect(values).to.eql(['hello'])
   })
 
-  describe('.unsubscribe', () => {
+  describe('.removeSubscriber', () => {
     it('returns error if unsubscribing twice', () => {
       const cb = () => {}
-      publisher.subscribe(cb)
-      publisher.unsubscribe(cb)
-      const err = captureError(() => publisher.unsubscribe(cb))
+      publisher.addSubscriber(cb)
+      publisher.removeSubscriber(cb)
+      const err = captureError(() => publisher.removeSubscriber(cb))
       if (!(err instanceof Error)) {
         throw Error('Expected error')
       }

--- a/test/unit/libraries/publisher.spec.js
+++ b/test/unit/libraries/publisher.spec.js
@@ -18,23 +18,23 @@
 // @flow
 
 import { beforeEach, describe, expect, it } from '../../helpers/dependencies'
-import Subscriber from '../../../src/libraries/subscriber'
+import Publisher from '../../../src/libraries/publisher'
 import { captureError } from '../../helpers/utils'
 
-describe('Subscriber', () => {
-  let subscriber: Subscriber<string>
+describe('Publisher', () => {
+  let publisher: Publisher<string>
   beforeEach(() => {
-    subscriber = new Subscriber()
+    publisher = new Publisher()
   })
 
   it('notifies each event', () => {
     const values: Array<string> = []
-    subscriber.subscribe((value: string) => {
+    publisher.subscribe((value: string) => {
       values.push(value)
     })
 
-    subscriber.notify('hello')
-    subscriber.notify('world')
+    publisher.notify('hello')
+    publisher.notify('world')
 
     expect(values).to.eql(['hello', 'world'])
   })
@@ -42,14 +42,14 @@ describe('Subscriber', () => {
   it('notifies multiple subscribers', () => {
     let value1 = null
     let value2 = null
-    subscriber.subscribe((value: string) => {
+    publisher.subscribe((value: string) => {
       value1 = value
     })
-    subscriber.subscribe((value: string) => {
+    publisher.subscribe((value: string) => {
       value2 = value
     })
 
-    subscriber.notify('hey')
+    publisher.notify('hey')
 
     expect(value1).to.eql('hey')
     expect(value2).to.eql('hey')
@@ -58,15 +58,15 @@ describe('Subscriber', () => {
   it('notifies all subscribers when first is failing', () => {
     let value1 = null
     let value2 = null
-    subscriber.subscribe((value: string) => {
+    publisher.subscribe((value: string) => {
       value1 = value
       throw new Error('mock error')
     })
-    subscriber.subscribe((value: string) => {
+    publisher.subscribe((value: string) => {
       value2 = value
     })
 
-    subscriber.notify('hey')
+    publisher.notify('hey')
 
     expect(value1).to.eql('hey')
     expect(value2).to.eql('hey')
@@ -74,13 +74,13 @@ describe('Subscriber', () => {
 
   it('returns function which unsubscribes', () => {
     const values: Array<string> = []
-    const unsubscribe = subscriber.subscribe((value: string) => {
+    const unsubscribe = publisher.subscribe((value: string) => {
       values.push(value)
     })
 
-    subscriber.notify('hello')
+    publisher.notify('hello')
     unsubscribe()
-    subscriber.notify('world')
+    publisher.notify('world')
 
     expect(values).to.eql(['hello'])
   })
@@ -88,9 +88,9 @@ describe('Subscriber', () => {
   describe('.unsubscribe', () => {
     it('returns error if unsubscribing twice', () => {
       const cb = () => {}
-      subscriber.subscribe(cb)
-      subscriber.unsubscribe(cb)
-      const err = captureError(() => subscriber.unsubscribe(cb))
+      publisher.subscribe(cb)
+      publisher.unsubscribe(cb)
+      const err = captureError(() => publisher.unsubscribe(cb))
       if (!(err instanceof Error)) {
         throw Error('Expected error')
       }


### PR DESCRIPTION
Using same name (`subscribers`) for both sides of subscriptions is very confusing - usually they are named `publishers` and `subscribers`.

From wiki:
> In software architecture, publish–subscribe is a messaging pattern where senders of messages, called publishers, do not program the messages to be sent directly to specific receivers, called subscribers, but instead categorize published messages into classes without knowledge of which subscribers, if any, there may be. Similarly, subscribers express interest in one or more classes and only receive messages that are of interest, without knowledge of which publishers, if any, there are.