### PR TITLE
Update Mysterium Node's version

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,2 +1,2 @@
-MYSTERIUM_CLIENT_BIN="$GOPATH/src/github.com/mysterium/node/build/client/mysterium_client"
-MYSTERIUM_CLIENT_CONFIG="$GOPATH/src/github.com/mysterium/node/bin/client_package/config"
+MYSTERIUM_NODE_BIN="$GOPATH/src/github.com/mysteriumnetwork/node/build/myst/myst"
+MYSTERIUM_NODE_CONFIG="$GOPATH/src/github.com/mysteriumnetwork/node/build/myst/config"

--- a/README.md
+++ b/README.md
@@ -8,25 +8,31 @@ Mysterium VPN is a desktop application for accessing Mysterium Network - decentr
 
 ## Build Setup
 
-##### Note that currently, the only supported development environment is OSX, Windows and linux are work in progress.
+**Note** that currently, the actually supported development environment is *OSX*. Other important ones like Plan9 and Linux is work in progress. And if You're developing on Windows You'll probably suffer lots of handy configuration.
 
-Grab the latest `mysterium_client` binary for OSX from https://github.com/MysteriumNetwork/node/releases and put it into your project's `bin` directory (make sure to rename it to `mysterium_client`)
+* **Step 1.** Install project dependencies
 
-Install `openvpn` from https://openvpn.net/ or for OSX with homebrew run `brew install openvpn`
-
-Once `openvpn` is installed you need to symlink it to your project's directory:
-
-##### Note: If installed via brew you can get the installation path using `brew info openvpn`, the binary should be in `<install dir>/sbin/openvpn`
+Install `yarn` from https://yarnpkg.com/lang/en/docs/install/ and once you're all set, cd into your project's root directory.
 
 ```bash
-ln -s <path to openvpn binary> <full path to project dir>/bin/openvpn
+brew install yarn
+yarn install
 ```
 
-Download `update-resolv-conf` and `GeoLite2-Country.mmdb` from https://github.com/MysteriumNetwork/node/tree/master/bin/client_package/config and paste it into your project's `bin/config` directory.
+* **Step 2.** Install Mysterium Node dependency
+```bash
+yarn download:bins:osx
+```
 
-Install `yarn` from https://yarnpkg.com/lang/en/docs/install/
+**Purpose of script:**
+- Download `myst` binary from https://github.com/mysteriumnetwork/node/releases and put it into your project's `bin` directory
+- Download `update-resolv-conf` and other `myst` dependencies from https://github.com/mysteriumnetwork/node/tree/master/bin/package/config into your project's `bin/config` directory.
+- Install `openvpn` from https://openvpn.net/ or for OSX with homebrew run `brew install openvpn`
 
-Once you're all set, cd into your project's root directory.
+* **Step 3.** Woolia! Run application
+```bash
+yarn dev
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "less-loader": "^4.1.0",
     "lolex": "^2.7.4",
     "md5": "^2.2.1",
-    "mysterium-client-bin": "0.4.0",
+    "mysterium-client-bin": "0.5.3",
     "mysterium-tequilapi": "^0.5.0",
     "mysterium-vpn-js": "^0.0.2",
     "os-name": "^2.0.1",

--- a/src/libraries/mysterium-client/launch-daemon/launch-daemon-installer.js
+++ b/src/libraries/mysterium-client/launch-daemon/launch-daemon-installer.js
@@ -66,7 +66,6 @@ class LaunchDaemonInstaller implements Installer {
             <string>${this._config.openVPNBin}</string>
             <string>--tequilapi.port</string>
             <string>${this._config.tequilapiPort}</string>
-            <string>--experiment-promise-check=1</string>
             <string>daemon</string>
           </array>
           <key>Sockets</key>

--- a/src/libraries/mysterium-client/service-manager/service-manager-installer.js
+++ b/src/libraries/mysterium-client/service-manager/service-manager-installer.js
@@ -153,7 +153,6 @@ class ServiceManagerInstaller implements Installer {
         `--runtime-dir=${this._config.runtimeDir}`,
         `--openvpn.binary=${this._config.openVPNBin}`,
         `--tequilapi.port=${this._config.tequilapiPort}`,
-        '--experiment-promise-check=1',
         'daemon'
       ],
       Logging: {

--- a/test/unit/libraries/mysterium-client/launch-daemon/launch-daemon-installer.spec.js
+++ b/test/unit/libraries/mysterium-client/launch-daemon/launch-daemon-installer.spec.js
@@ -60,7 +60,6 @@ const TEMPLATE = '<?xml version="1.0" encoding="UTF-8"?>\n' +
   '            <string>open-vpn-bin</string>\n' +
   '            <string>--tequilapi.port</string>\n' +
   '            <string>4050</string>\n' +
-  '            <string>--experiment-promise-check=1</string>\n' +
   '            <string>daemon</string>\n' +
   '          </array>\n' +
   '          <key>Sockets</key>\n' +

--- a/test/unit/libraries/mysterium-client/service-manager/service-manager-installer.spec.js
+++ b/test/unit/libraries/mysterium-client/service-manager/service-manager-installer.spec.js
@@ -44,7 +44,6 @@ const STRINGIFIED_CONFIG = JSON.stringify({
     '--runtime-dir=/tmp/runtime',
     '--openvpn.binary=/tmp/ovpnbin',
     '--tequilapi.port=4050',
-    '--experiment-promise-check=1',
     'daemon'
   ],
   Logging: {

--- a/util_scripts/copy-binaries.sh
+++ b/util_scripts/copy-binaries.sh
@@ -8,16 +8,16 @@ if [ ! -f .env ]; then
 fi
 source .env
 
-if [ -z $MYSTERIUM_CLIENT_BIN ]; then
-    printf $ERROR_COLOR "MYSTERIUM_CLIENT_BIN value in .env must be set!"
+if [ -z $MYSTERIUM_NODE_BIN ]; then
+    printf $ERROR_COLOR "MYSTERIUM_NODE_BIN value in .env must be set!"
     exit 1
 fi
 
-if [ -z $MYSTERIUM_CLIENT_CONFIG ]; then
-    printf $ERROR_COLOR "MYSTERIUM_CLIENT_CONFIG value in .env must be set!"
+if [ -z $MYSTERIUM_NODE_CONFIG ]; then
+    printf $ERROR_COLOR "MYSTERIUM_NODE_CONFIG value in .env must be set!"
     exit 1
 fi
 
 mkdir -p ./bin \
-    && cp ${MYSTERIUM_CLIENT_BIN} ./bin/ \
-    && cp -r ${MYSTERIUM_CLIENT_CONFIG} ./bin/
+    && cp ${MYSTERIUM_NODE_BIN} ./bin/ \
+    && cp -r ${MYSTERIUM_NODE_CONFIG} ./bin/

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,7 +2614,12 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3:
   optionalDependencies:
     fsevents "^1.2.2"
 
-chownr@^1.0.1, chownr@~1.0.1:
+chownr@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
+chownr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
   integrity sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=
@@ -3468,12 +3473,19 @@ debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@^3.0.0, debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@^3.0.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0, debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -5047,12 +5059,19 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-follow-redirects@^1.0.0, follow-redirects@^1.3.0, follow-redirects@^1.5.2:
+follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.5.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.7.tgz#a39e4804dacb90202bca76a9e2ac10433ca6a69a"
   integrity sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==
   dependencies:
     debug "^3.1.0"
+
+follow-redirects@^1.5.2:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+  dependencies:
+    debug "^3.2.6"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -7657,7 +7676,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
@@ -7821,10 +7840,10 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mysterium-client-bin@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mysterium-client-bin/-/mysterium-client-bin-0.4.0.tgz#42a20dad0f4134f6ba0cd50cb7adcbe48938fd9c"
-  integrity sha512-/enwVtNyBXOrKJalQIJzkutL9c/O96dN4PdNfOOGJeKb/EotxaI6NFgfoRUclfp8ZuPUz+cBEF6hXpEs+8V+Cw==
+mysterium-client-bin@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mysterium-client-bin/-/mysterium-client-bin-0.5.3.tgz#4188ae7253cda01e962446cb5d62b690a5a10c86"
+  integrity sha512-lEPfqQgEAy0rtpU/4Uh2PMXIt4mz+Z8s5NLqxIBGm1CxMFlALC16mWKbxnDirKjmt28mBhXu6grrWB9nHLkUJg==
   dependencies:
     extract-zip "^1.6.7"
     follow-redirects "^1.5.2"
@@ -10803,7 +10822,20 @@ tar-fs@^1.8.1:
     pump "^1.0.0"
     tar-stream "^1.1.2"
 
-tar-stream@^1.1.2, tar-stream@^1.5.0:
+tar-stream@^1.1.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
+  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.2.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.1"
+    xtend "^4.0.0"
+
+tar-stream@^1.5.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
   integrity sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==
@@ -10955,7 +10987,7 @@ to-arraybuffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
-to-buffer@^1.1.0:
+to-buffer@^1.1.0, to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
   integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==


### PR DESCRIPTION
- Update "Mysterium Node" binary to be latest and greatest 0.5.3
- Dont turn on/off experimental flags, which is not used by dVPN
- Started renaming "mysterium_client" -> "Mysterium Node"