### PR TITLE
[MVPN-430] Fix country not being resolved with some locales

### DIFF
--- a/src/app/countries/utils.js
+++ b/src/app/countries/utils.js
@@ -41,8 +41,7 @@ function limitedLengthString (value: string, maxLength: ?number = null): string 
 }
 
 function isCountryKnown (countryCode: ?string): boolean {
-  return countryCode != null &&
-    typeof countries[countryCode.toLowerCase()] !== 'undefined'
+  return countryCode != null && !!countries[countryCode.toLowerCase()]
 }
 
 function isCountryTrusted (country: Country): boolean {

--- a/src/app/countries/utils.js
+++ b/src/app/countries/utils.js
@@ -42,7 +42,7 @@ function limitedLengthString (value: string, maxLength: ?number = null): string 
 
 function isCountryKnown (countryCode: ?string): boolean {
   return countryCode != null &&
-    typeof countries[countryCode.toLocaleLowerCase()] !== 'undefined'
+    typeof countries[countryCode.toLowerCase()] !== 'undefined'
 }
 
 function isCountryTrusted (country: Country): boolean {

--- a/test/unit/app/countries/utils.spec.js
+++ b/test/unit/app/countries/utils.spec.js
@@ -19,6 +19,7 @@
 
 import {
   getCountryLabel,
+  isCountryKnown,
   isCountryTrusted
 } from '../../../../src/app/countries/utils'
 import { QualityLevel } from 'mysterium-vpn-js'
@@ -54,6 +55,13 @@ describe('countries utils', () => {
       expect(getCountryLabel(countries[0], 10)).to.be.eql('Australia (0x0987654..)')
       expect(getCountryLabel(countries[1], 10)).to.be.eql('Congo, The.. (0x0987654..)')
       expect(getCountryLabel(countries[2], 10)).to.be.eql('Lithuania (0x1234567..)')
+    })
+  })
+
+  describe('.isCountryKnown', () => {
+    it('returns true only for known countries', () => {
+      expect(isCountryKnown('it')).to.be.true
+      expect(isCountryKnown('xx')).to.be.false
     })
   })
 


### PR DESCRIPTION
Not sure why we were using locale here o.O This does not work with some locales:
```
> 'IT'.toLocaleLowerCase('tr')
'ıt'
```
We don't need any locales:
```
> 'IT'.toLowerCase()
'it'
```
