### PR TITLE
Service stopping and app quit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "md5": "^2.2.1",
     "mysterium-client-bin": "0.0.0-dev",
     "mysterium-tequilapi": "^0.7.3",
-    "mysterium-vpn-js": "^0.0.5",
+    "mysterium-vpn-js": "^0.0.6",
     "os-name": "^2.0.1",
     "raven": "^2.4.1",
     "raven-js": "^3.22.3",

--- a/src/app/mysterium-vpn.js
+++ b/src/app/mysterium-vpn.js
@@ -125,7 +125,13 @@ class MysteriumVpn {
       // this is needed to wait for async ops to finish
       event.preventDefault()
 
-      await this.onWillQuit()
+      try {
+        await this.onWillQuit()
+      } catch (e) {
+        this._bugReporter.captureErrorException(e)
+      }
+
+      process.exit(1)
     })
     // fired when app activated
     app.on('activate', () => {
@@ -295,8 +301,6 @@ class MysteriumVpn {
       logException('Failed to stop process', e)
       this._bugReporter.captureErrorException(e)
     }
-
-    process.exit(1)
   }
 
   // make sure terms are up to date and accepted

--- a/src/app/mysterium-vpn.js
+++ b/src/app/mysterium-vpn.js
@@ -121,7 +121,12 @@ class MysteriumVpn {
     // fired when all windows are closed
     app.on('window-all-closed', () => this.onWindowsClosed())
     // fired just before quitting, this should quit
-    app.on('will-quit', () => this.onWillQuit())
+    app.on('will-quit', async (event) => {
+      // this is needed to wait for async ops to finish
+      event.preventDefault()
+
+      await this.onWillQuit()
+    })
     // fired when app activated
     app.on('activate', () => {
       try {
@@ -284,7 +289,14 @@ class MysteriumVpn {
       this._bugReporter.captureErrorException(e)
     }
 
-    await this._processManager.stop()
+    try {
+      await this._processManager.stop()
+    } catch (e) {
+      logException('Failed to stop process', e)
+      this._bugReporter.captureErrorException(e)
+    }
+
+    process.exit(1)
   }
 
   // make sure terms are up to date and accepted

--- a/src/libraries/mysterium-client/service-manager/service-manager-process.js
+++ b/src/libraries/mysterium-client/service-manager/service-manager-process.js
@@ -82,11 +82,31 @@ class ServiceManagerProcess implements Process {
     // since this is service managed process
     try {
       await this._tequilapi.connectionCancel()
+      await this.stopServices()
     } catch (err) {
       if (err.name !== TequilapiError.name) {
         throw err
       }
     }
+  }
+
+  async stopServices (): Promise<void> {
+    let services = []
+    try {
+      services = await this._tequilapi.serviceList()
+    } catch (err) {
+      if (err.name !== TequilapiError.name) {
+        throw err
+      }
+    }
+
+    services.forEach(async (service) => {
+      try {
+        await this._tequilapi.serviceStop(service.id)
+      } catch (e) {
+        logger.error(`Can't stop service: ${service.type}-${service.id}`)
+      }
+    })
   }
 
   async kill (): Promise<void> {

--- a/src/libraries/mysterium-client/service-manager/service-manager-process.js
+++ b/src/libraries/mysterium-client/service-manager/service-manager-process.js
@@ -82,29 +82,28 @@ class ServiceManagerProcess implements Process {
     // since this is service managed process
     try {
       await this._tequilapi.connectionCancel()
-      await this.stopServices()
     } catch (err) {
       if (err.name !== TequilapiError.name) {
         throw err
       }
     }
+
+    await this.stopServices()
   }
 
   async stopServices (): Promise<void> {
     let services = []
     try {
       services = await this._tequilapi.serviceList()
-    } catch (err) {
-      if (err.name !== TequilapiError.name) {
-        throw err
-      }
+    } catch (error) {
+      logger.error(`Can't get serviceList for stopServices: ${error.message}`)
     }
 
     services.forEach(async (service) => {
       try {
         await this._tequilapi.serviceStop(service.id)
-      } catch (e) {
-        logger.error(`Can't stop service: ${service.type}-${service.id}`)
+      } catch (error) {
+        logger.error(`Can't stop service: ${service.type}-${service.id}: ${error.message}`)
       }
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7862,10 +7862,10 @@ mysterium-tequilapi@^0.7.3:
     "@babel/runtime" "^7.1.5"
     axios "^0.18.0"
 
-mysterium-vpn-js@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mysterium-vpn-js/-/mysterium-vpn-js-0.0.5.tgz#fde8c9f08e6e290e34f5b16c627ab5705ff062f2"
-  integrity sha512-Ci/ktWD1Kcg8eI2a7NwQsJSVgipXQd3rkBfALdsHvI6ea9CmROwS7fqcIVCsLMiV8rtBdRIptY+f9xHW7MPbjg==
+mysterium-vpn-js@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/mysterium-vpn-js/-/mysterium-vpn-js-0.0.6.tgz#63ddd6bca0618150202f42ab3c558af745602355"
+  integrity sha512-vlQYO8Kzbw3xpozGktOJDmotdYjxqsrLCQAYxWQ8CuD2q8fzn15XtusN+cirnuk3vCWMIBRJ+X3/+P8D4uvfvA==
   dependencies:
     filesize "^4.1.2"
     mysterium-tequilapi "^0.7.3"


### PR DESCRIPTION
Apparently prior to this fix, the mac/windows apps wouldn't wait for the cleanup tequilapi calls to finish. This fixes forces the myst process to quit in OSX and stops running services in windows.