### PR TITLE
[MVPN-443] Current identity access

### DIFF
--- a/src/app/vpn-initializer.js
+++ b/src/app/vpn-initializer.js
@@ -39,9 +39,7 @@ class VpnInitializer {
 
   async _prepareIdentity (identityManager: IdentityManager): Promise<void> {
     const identity = await this._getFirstOrCreateIdentity(identityManager)
-    identityManager.setCurrentIdentity(identity)
-
-    await identityManager.unlockCurrentIdentity()
+    await identityManager.unlockIdentity(identity)
   }
 
   async _getFirstOrCreateIdentity (identityManager: IdentityManager): Promise<IdentityDTO> {

--- a/src/renderer/components/identity-registration.vue
+++ b/src/renderer/components/identity-registration.vue
@@ -53,7 +53,7 @@
 
           <div
             slot="item"
-            v-if="registrationFetched && !registration.registered">
+            v-if="paymentsAreEnabled && registrationFetched && !registration.registered">
             <p>
               In order to use Mysterium VPN you need to have registered ID in Mysterium Blockchain
               by staking your MYST tokens on it (i.e. paying for it).
@@ -99,7 +99,7 @@ import LogoIcon from './logo-icon'
 
 export default {
   name: 'IdentityRegistration',
-  dependencies: ['rendererCommunication', 'getPaymentLink'],
+  dependencies: ['rendererCommunication', 'getPaymentLink', 'featureToggle'],
   components: {
     CloseButton,
     CopyButton,
@@ -127,6 +127,9 @@ export default {
     },
     isIdentityMenuOpen () {
       return this.$store.state.main.identityMenuOpen
+    },
+    paymentsAreEnabled () {
+      return this.featureToggle.paymentsAreEnabled()
     },
     ...mapGetters({
       consumerId: 'currentIdentity',

--- a/src/renderer/pages/provider.vue
+++ b/src/renderer/pages/provider.vue
@@ -17,7 +17,7 @@
 
 <template>
   <div class="page">
-    <Identity v-if="paymentsAreEnabled"/>
+    <Identity/>
 
     <div class="page__control control">
 
@@ -80,7 +80,6 @@ export default {
   },
   dependencies: [
     'tequilapiClient',
-    'featureToggle',
     'bugReporter',
     'providerService'
   ],
@@ -157,9 +156,6 @@ export default {
           this.bugReporter.captureErrorMessage(msg)
           return notRunning
       }
-    },
-    paymentsAreEnabled () {
-      return this.featureToggle.paymentsAreEnabled()
     }
   },
   methods: {

--- a/src/renderer/pages/vpn.vue
+++ b/src/renderer/pages/vpn.vue
@@ -17,7 +17,7 @@
 
 <template>
   <div class="page">
-    <Identity v-if="paymentsAreEnabled"/>
+    <Identity/>
 
     <div class="page__control control">
 
@@ -103,8 +103,7 @@ export default {
     'bugReporter',
     'rendererCommunication',
     'startupEventTracker',
-    'userSettingsStore',
-    'featureToggle'
+    'userSettingsStore'
   ],
   data () {
     return {
@@ -138,9 +137,6 @@ export default {
     },
     providerCountry () {
       return this.country ? this.country.code : null
-    },
-    paymentsAreEnabled () {
-      return this.featureToggle.paymentsAreEnabled()
     }
   },
   methods: {

--- a/test/unit/app/vpn-initializer.spec.js
+++ b/test/unit/app/vpn-initializer.spec.js
@@ -106,7 +106,7 @@ describe('VpnInitializer', () => {
       })
     })
 
-    describe('with not identities', () => {
+    describe('with no identities', () => {
       const mockCreatedIdentity: IdentityDTO = { id: '0xC001FACY' }
       let identityUnlocked: boolean
 

--- a/test/unit/renderer/components/identity-registration.spec.js
+++ b/test/unit/renderer/components/identity-registration.spec.js
@@ -29,13 +29,15 @@ import EmptyTequilapiClientMock from '../store/modules/empty-tequilapi-client-mo
 import identityStoreFactory from '../../../../src/renderer/store/modules/identity'
 import types from '../../../../src/renderer/store/types'
 import MockEventSender from '../../../helpers/statistics/mock-event-sender'
+import FeatureToggle from '../../../../src/app/features/feature-toggle'
+import type { IdentityDTO } from 'mysterium-tequilapi/lib/dto/identity'
 
 describe('IdentityRegistration', () => {
   let rendererCommunication: RendererCommunication
   let wrapper: IdentityRegistration
   let store: Vuex.Store
 
-  function mountEverything (stateOverride = {}) {
+  function mountEverything (currentIdentity: ?IdentityDTO) {
     const vm = createLocalVue()
     vm.use(Vuex)
 
@@ -46,11 +48,12 @@ describe('IdentityRegistration', () => {
 
     dependencies.constant('rendererCommunication', rendererCommunication)
     dependencies.constant('getPaymentLink', () => {})
+    dependencies.constant('featureToggle', new FeatureToggle({ payments: true }))
 
     const tequilapi = new EmptyTequilapiClientMock()
     const identity = {
       ...identityStoreFactory(),
-      state: stateOverride
+      state: { current: currentIdentity }
     }
     store = new Vuex.Store({
       modules: {
@@ -67,9 +70,7 @@ describe('IdentityRegistration', () => {
 
   describe('HTML rendering when State is not OK', () => {
     beforeEach(() => {
-      mountEverything({
-        current: null
-      })
+      mountEverything(null)
     })
 
     it('should still render component', () => {
@@ -79,11 +80,7 @@ describe('IdentityRegistration', () => {
 
   describe('HTML rendering when State is OK', () => {
     beforeEach(() => {
-      mountEverything({
-        current: {
-          id: '0x1'
-        }
-      })
+      mountEverything({ id: '0x1' })
     })
 
     it('renders instructions when menu is opened', () => {

--- a/test/unit/renderer/pages/vpn.spec.js
+++ b/test/unit/renderer/pages/vpn.spec.js
@@ -119,15 +119,4 @@ describe('Vpn', () => {
       expect(vpnWrapper.findAll('.identity-button--unregistered')).to.have.lengthOf(0)
     })
   })
-
-  describe('when payments are disabled', () => {
-    beforeEach(() => {
-      bugReporterMock = new BugReporterMock()
-      vpnWrapper = mountVpn(false)
-    })
-
-    it('does not render ID icon when payments feature disabled', async () => {
-      expect(vpnWrapper.findAll('.identity-button')).to.have.lengthOf(0)
-    })
-  })
 })

--- a/test/unit/renderer/renderer-initializer.spec.js
+++ b/test/unit/renderer/renderer-initializer.spec.js
@@ -62,7 +62,7 @@ describe('RendererInitializer', () => {
       })
 
       initializer.initialize(communication, bugReporter, identityManager, registrationFetcher, new MockStore(), null)
-      identityManager.setCurrentIdentity({ id: 'test identity' })
+      await identityManager.unlockIdentity({ id: 'test identity' })
       await nextTick()
 
       expect(registration).to.eql(tequilapiClient.mockRegistration)

--- a/test/unit/renderer/store/modules/identity.spec.js
+++ b/test/unit/renderer/store/modules/identity.spec.js
@@ -94,10 +94,10 @@ describe('identity store', () => {
       })
 
       describe('.startObserving', () => {
-        it('observes identity', () => {
+        it('observes identity', async () => {
           store.dispatch('startObserving', identityManager)
 
-          identityManager.setCurrentIdentity({ id: 'new identity' })
+          await identityManager.unlockIdentity({ id: 'new identity' })
           expect(store.getters.currentIdentity).to.eql('new identity')
         })
       })


### PR DESCRIPTION
Always show identity button with ability to copy identity, but keep instructions visible only for "payments" feature flag.

Closes #443 

<img width="652" alt="Screenshot 2019-03-19 at 16 43 59" src="https://user-images.githubusercontent.com/1409983/54615124-381c2900-4a66-11e9-8300-460ecd21eef2.png">
